### PR TITLE
Zero out event trace properties

### DIFF
--- a/C/STrace/Etw.cpp
+++ b/C/STrace/Etw.cpp
@@ -100,6 +100,7 @@ PEVENT_TRACE_PROPERTIES_V2 AllocEventProperties()
         return NULL;
     }
 
+    memset(eventProperties, 0, eventPropertiesSize);
     eventProperties->Wnode.BufferSize = 0xB0;
     eventProperties->Wnode.Flags = WNODE_FLAG_TRACED_GUID;
     eventProperties->Wnode.Guid = ETW_SESSION_GUID;


### PR DESCRIPTION
The commit [e7118d4](https://github.com/mandiant/STrace/pull/9/commits/e7118d43b290bf24d5ea6effcaab55e6da11bd0a) switches the code to using ExAllocatePoolWithTag, which doesn't zero out the memory on allocation. This was causing the ETW session initialisation functions to read junk as flags and start to reject the session, so failing any plugin load that wanted to use ETW. The fix is simple though, I probably should of had this before anyway.